### PR TITLE
fix http:/ or https:/ slashes in filePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ module.exports = function (content) {
         .filter(Boolean)
         .join(pathSep)
         .replace(new RegExp(escapeRegExp(pathSep) + '+', 'g'), pathSep);
+
+    filePath = filePath.replace(/(https?):\/(?!\/)/, "$1://");
     
     // Replace the default export with an assigment to the _module_exports variable.
     var exportRe = /module\.exports\s*=|export default\s+/g;


### PR DESCRIPTION
In our webpack configuration, we use `ngtemplate-loader` with `html-loader` to collect all of the angular templates under `kinnek/kinnek/static/webpack` and `kinnek/kinnek/static/v2` and populate a `$templateCache` to be included in the bundle, so we don't need make separate trips to our CDN for each individual template.

This `$templateCache` is supposed to be populated with the full url of the template as the key, including the domain, which is environment-dependent, e.g., `https://feature1-resources.kinnek.com/static/kinnek/kinnek/v2/js/components/shelfForm/shelfForm.tpl.html`.  In our `static/v2` angular components, we generally use `Utils.templateUrl` to generate the templateUrl for each directive so that it perfectly matches these environment-dependent keys.  However, because of the last line of this bit of `ngtemplate-loader` code
```
    var filePath = [prefix, resource.slice(relativeToIndex + relativeTo.length)]
        .filter(Boolean)
        .join(pathSep)
        .replace(new RegExp(escapeRegExp(pathSep) + '+', 'g'), pathSep);
```
a path like
`https://feature1-resources.kinnek.com/static/kinnek/kinnek/v2/js/components/shelfForm/shelfForm.tpl.html` becomes
`https:/feature1-resources.kinnek.com/static/kinnek/kinnek/v2/js/components/shelfForm/shelfForm.tpl.html`, i.e., `http://` gets replaced by `http:/`, which causes a miss in `$templateCache` and the template isn't loaded properly. 

So this PR hacks a line into this `ngtemplate-loader` code:
```
filePath = filePath.replace(/(https?):\/(?!\/)/, "$1://");
```
which restores the the two slashes in `https://`.

